### PR TITLE
Update to Argo 3

### DIFF
--- a/Moya-Argo.podspec
+++ b/Moya-Argo.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.subspec "Core" do |ss|
     ss.source_files = "Pod/Classes/*.swift"
     ss.dependency "Moya"
-    ss.dependency "Argo"
+    ss.dependency "Argo", "~> 3.0.0"
     ss.framework = "Foundation"
   end
 


### PR DESCRIPTION
Argo 3.0.0 changed the API regarding decoding objects with root keys. Without an explicit version specified CocoaPods pulled Argo 3, but this library is expecting Argo 2.

This PR specifies a dependency on Argo 3 and changes to use the new API. Tests still pass.
